### PR TITLE
update org.owasp dependency-check-maven to 5.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 				<plugin>
 					<groupId>org.owasp</groupId>
 					<artifactId>dependency-check-maven</artifactId>
-					<version>3.3.4</version>
+					<version>5.2.2</version>
 					<executions>
 						<execution>
 							<goals>


### PR DESCRIPTION
Update dependency-check plugin.
nist.gov no longer provide in xml format. Switch to json.